### PR TITLE
run 'npm update' after 'npm install'

### DIFF
--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -34,7 +34,7 @@ deps-npm:
 	fi
 	$(NPM) prune
 	[[ -f "package-lock.json" ]] || \
-		$(NPM) update --no-save --depth 9999 --development
+		$(NPM) update --no-save --development
 
 
 .PHONY: deps-npm-prod
@@ -42,4 +42,4 @@ deps-npm-prod:
 	$(NPM) install --production
 	$(NPM) prune --production
 	[[ -f "package-lock.json" ]] || \
-		$(NPM) update --no-save --depth 9999 --production
+		$(NPM) update --no-save --production

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -33,6 +33,7 @@ deps-npm:
 		node_modules/eslint-config-firecloud/npm-install-peer-dependencies; \
 	fi
 	$(NPM) update --development --no-save --depth 9999
+	$(NPM) prune
 
 
 .PHONY: deps-npm-prod

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -34,7 +34,7 @@ deps-npm:
 	fi
 	$(NPM) prune
 	[[ -f "package-lock.json" ]] || \
-		$(NPM) update --development --no-save --depth 9999
+		$(NPM) update --no-save --depth 9999 --development
 
 
 .PHONY: deps-npm-prod
@@ -42,4 +42,4 @@ deps-npm-prod:
 	$(NPM) install --production
 	$(NPM) prune --production
 	[[ -f "package-lock.json" ]] || \
-		$(NPM) update --production --no-save --depth 9999
+		$(NPM) update --no-save --depth 9999 --production

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -32,12 +32,14 @@ deps-npm:
 	if [[ -x node_modules/eslint-config-firecloud/npm-install-peer-dependencies ]]; then \
 		node_modules/eslint-config-firecloud/npm-install-peer-dependencies; \
 	fi
-	$(NPM) update --development --no-save --depth 9999
 	$(NPM) prune
+	[[ -f "package-lock.json" ]] || \
+		$(NPM) update --development --no-save --depth 9999
 
 
 .PHONY: deps-npm-prod
 deps-npm-prod:
 	$(NPM) install --production
 	$(NPM) prune --production
-	$(NPM) update --production --no-save --depth 9999
+	[[ -f "package-lock.json" ]] || \
+		$(NPM) update --production --no-save --depth 9999

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -32,9 +32,11 @@ deps-npm:
 	if [[ -x node_modules/eslint-config-firecloud/npm-install-peer-dependencies ]]; then \
 		node_modules/eslint-config-firecloud/npm-install-peer-dependencies; \
 	fi
+	$(NPM) update --development --no-save --depth 9999
 
 
 .PHONY: deps-npm-prod
 deps-npm-prod:
 	$(NPM) install --production
 	$(NPM) prune --production
+	$(NPM) update --production --no-save --depth 9999


### PR DESCRIPTION
to refresh dependencies to the latest matching version. I got bit by a bug in the jest ecosystem recently, a bug which wasn't seen on Travis, but "only on my computer"

Downside: time. This adds another 10+ seconds to `make deps/npm`. In theory `npm install` can be **replaced** by `npm update` but I don't want to put my trust in `npm` maintaining that behaviour.

Open for suggestions or just not doing it 🤷‍♂️ 
