### PR TITLE
handle semver

### DIFF
--- a/doc/how-to-release.md
+++ b/doc/how-to-release.md
@@ -4,6 +4,31 @@ Below you will find flows that focus on `npm` packages, but they are generic at 
 and they can be followed closely even for other type of packages.
 
 
+## Semantic Versioning
+
+See https://semver.org/spec/v2.0.0.html .
+
+**TL;DR** :
+
+* pre-public versions
+  * `0.0.1` initial version
+  * `0.0.2` minor version with **bugfixes, new features**
+  * `0.1.0` major version with bugfixes, new features, **breaking changes**
+* public versions
+  * `1.0.0` initial public version
+  * `1.0.1` patch version with **bugfixes**
+  * `1.1.0` minor version with bugfixes, **new features**
+  * `2.0.0` major version with bugfixes, new features, **breaking changes**
+
+
+**You don't need to remember all of these if you use the `make release/*` targets below.**
+
+* `make release/bugfix` will be `make release/patch` for both pre- and public versions
+* `make release/feature` will be `make release/patch` for pre-, and `make release/minor` for public versions
+* `make release/breaking` will be `make release/minor` for pre-, and `make release/major` for public versions
+* `make release/public` will release `1.0.0`
+
+
 ## `npm` packages as `git` tags (libraries, frameworks, etc)
 
 **NOTE** This section applies primarily, if not only, to packages which you intend to use

--- a/repo/mk/js.common.mk
+++ b/repo/mk/js.common.mk
@@ -2,6 +2,7 @@ SUPPORT_FIRECLOUD_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))/
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/generic.common.mk
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/js.deps.npm.mk
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/js.misc.version.mk
+include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/js.misc.release.mk
 
 # ------------------------------------------------------------------------------
 

--- a/repo/mk/js.misc.release.mk
+++ b/repo/mk/js.misc.release.mk
@@ -1,0 +1,52 @@
+RELEASE_SEMANTIC_LEVELS := \
+	bugfix \
+	feature \
+	breaking \
+
+RELEASE_SEMANTIC_TARGETS := $(patsubst %,release/%,$(RELEASE_SEMANTIC_LEVELS))
+
+# <1.0.0
+PREPUBLIC_bugfix := patch
+PREPUBLIC_feature := patch
+PREPUBLIC_breaking := minor
+
+# >=1.0.0
+PUBLIC_bugfix := patch
+PUBLIC_feature := minor
+PUBLIC_breaking := major
+
+# ------------------------------------------------------------------------------
+
+.PHONY: release
+release: release-patch ## Release a new patch version.
+
+
+.PHONY: release/public
+release/public: ## Release the first public version 1.0.0.
+ifeq (true,$(PKG_VSN_PUBLIC))
+	$(ECHO_ERR) "Current version $(PKG_VSN) is beyond first public version (>=1.0.0)."
+	exit 1
+endif
+	$(MAKE) release-f/major
+
+
+.PHONY: $(RELEASE_SEMANTIC_TARGETS)
+# NOTE: below is a workaround for `make help` to work
+release/bugfix: ## Release a new semantic version with bugfix level.
+release/feature: ## Release a new semantic version with feature level.
+release/breaking: ## Release a new semantic version with breaking level.
+$(RELEASE_SEMANTIC_TARGETS): release/%:
+	$(eval RELEASE_SEMANTIC_LEVEL := $*)
+ifeq (true,$(PKG_VSN_PUBLIC))
+	$(eval RELEASE_LEVEL := $(PUBLIC_$(RELEASE_SEMANTIC_LEVEL)))
+else
+	$(eval RELEASE_LEVEL := $(PREPUBLIC_$(RELEASE_SEMANTIC_LEVEL)))
+	$(ECHO_INFO) "Current version $(PKG_VSN) is pre-public (<1.0.0)."
+endif
+	$(eval PKG_VSN_NEW := $(shell $(NPX) semver --increment $(RELEASE_LEVEL) $(PKG_VSN)))
+	$(ECHO)
+	$(ECHO) "[Q   ] New $(RELEASE_SEMANTIC_LEVEL) release means new $(RELEASE_LEVEL) release: $(PKG_VSN) => $(PKG_VSN_NEW). Correct?"
+	$(ECHO) "       Wait 10 seconds or press ENTER to Continue."
+	$(ECHO) "       Press Ctrl+C to Cancel."
+	read -t 10 -p ""
+	$(MAKE) release/$(RELEASE_LEVEL)

--- a/repo/mk/js.misc.release.mk
+++ b/repo/mk/js.misc.release.mk
@@ -45,7 +45,8 @@ else
 endif
 	$(eval PKG_VSN_NEW := $(shell $(NPX) semver --increment $(RELEASE_LEVEL) $(PKG_VSN)))
 	$(ECHO)
-	$(ECHO) "[Q   ] New $(RELEASE_SEMANTIC_LEVEL) release means new $(RELEASE_LEVEL) release: $(PKG_VSN) => $(PKG_VSN_NEW). Correct?"
+	$(ECHO) "       New $(RELEASE_SEMANTIC_LEVEL) release means new $(RELEASE_LEVEL) release."
+	$(ECHO) "[Q   ] $(PKG_VSN) => $(PKG_VSN_NEW). Correct?"
 	$(ECHO) "       Wait 10 seconds or press ENTER to Continue."
 	$(ECHO) "       Press Ctrl+C to Cancel."
 	read -t 10 -p ""

--- a/repo/mk/js.misc.version.mk
+++ b/repo/mk/js.misc.version.mk
@@ -1,11 +1,19 @@
+PKG_VSN = $(shell $(CAT) package.json | $(JQ) ".version")
+PKG_VSN_MAJOR = $(shell $(ECHO) "$(PKG_VSN)" | $(CUT) -d"." -f1)
+PKG_VSN_PUBLIC =
+ifneq (0,$(PKG_VSN_MAJOR))
+PKG_VSN_PUBLIC = true
+endif
+$(foreach VAR,PKG_VSN PKG_VSN_MAJOR PKG_VSN_PUBLIC,$(call make-lazy,$(VAR)))
+
 # ------------------------------------------------------------------------------
 
 .PHONY: version
-version: version/patch ## Bump version (patch level).
+version: version/patch ## Bump patch version.
 
 
 .PHONY: version/%
-version/%: ## Bump version to given level (major/minor/patch).
+version/%: ## Bump major/minor/patch version.
 	@$(ECHO_DO) "Bumping $* version..."
 	$(NPM) version $*
 	@$(ECHO_DONE)

--- a/repo/mk/js.publish.npg.mk
+++ b/repo/mk/js.publish.npg.mk
@@ -17,12 +17,8 @@ publish/%: ## Publish as given git tag.
 	@$(ECHO_DONE)
 
 
-.PHONY: release
-release: release/patch ## Release a new version (patch level).
-
-
 .PHONY: release/%
-release/%: ## Release a new version with given level (major/minor/patch).
+release/%: ## Release a new version with major/minor/patch level.
 	@$(ECHO_DO) "Release new $* version..."
 	$(MAKE) nuke all test version/$* publish
 	sleep 15 # allow CI to pick the new tag first

--- a/repo/mk/js.publish.tag.mk
+++ b/repo/mk/js.publish.tag.mk
@@ -12,12 +12,8 @@ publish/%:
 	@$(ECHO_DONE)
 
 
-.PHONY: release
-release: release/patch ## Release a new version (patch level).
-
-
 .PHONY: release/%
-release/%: ## Release a new version with given level (major/minor/patch).
+release/%: ## Release a new version with major/minor/patch level.
 	@$(ECHO_DO) "Release new $* version..."
 	$(MAKE) version/$* publish
 	sleep 15 # allow CI to pick the new tag first


### PR DESCRIPTION
stemming from https://github.com/tobiipro/schemata-firecloud/commit/2cd5932e41dffbb234f77ceec81c34a612c70a9d#commitcomment-31730130

I guess at least the first part in the "Semantic Versioning" should stay, even if the rest doesn't get merged in.

PS: we could have convenience targets instead, and NOT mess up with changing the levels e.g.
* `make release/bugfix` would always do `make release/patch`
* `make release/feat` would do patch or minor, depending on pre/public
* `make release/break` would do minor or major, depending on pre/public