### PR TITLE
change template for "travis branches" builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ env:
 # 3. Git
 # git:
 branches:
-  except:
-    - /^f\// # feature branches require PR
+  only:
+    - master
 
 # 4. Bootstrap
 # os: linux

--- a/repo/dot.travis.yml
+++ b/repo/dot.travis.yml
@@ -18,8 +18,8 @@ env:
 git:
   submodules: false
 branches:
-  except:
-    - /^f\// # feature branches require PR
+  only:
+    - master
 
 # 4. Bootstrap
 os: linux


### PR DESCRIPTION
after https://github.com/tobiipro/support-firecloud/pull/66
trying to change a page via the Github UI, will actually create a new branch
named <destination-branch>-<unique-id> e.g. master-1 and then travis will start building

we also know that the `f/` prefix is not followed by everyone,
so this is slightly more liberal for humans, while still restrictive for the travis machines

---

the pattern suits gs-client, and we can make the other repos with "environments" to follow the pattern of "*-master" if you want an environment, so that we don't have "*-env" anymore. just a thought