### PR TITLE
stop requiring github branches to be up to date - not up to par in it…

### DIFF
--- a/doc/working-with-git-new.md
+++ b/doc/working-with-git-new.md
@@ -79,7 +79,6 @@ going to `Settings` tab -> `Branches` -> `Add rule`.
 * type `master`
 * **optionally** select `Require pull request reviews before merging`
 * select `Require status checks to pass before merging`
-  * select `Require branches to be up to date before merging`
   * select `Travis CI - Pull Request`
     * if not available, set up Travis CI integration first
 * click `Create`


### PR DESCRIPTION
…s current form

annoyances:
* rebasing is manual
* rebasing may be required extremely often even in a mildly active repo
* "Update branch" button in github gui does the "wrong" (TM) thing - it merges master into the PR branches, rather than rebasing it
* there's no way to automatically rebase (say once a day)
* having this enabled across all repos is more of a "let's see errors everywhere and ignore them" rather than pay attention to some meaningful error

PS: to be followed by manually disabling the check in our repos

Do as you see fit in your repo/s @tobiiasl since you triggered this. ref #60 