### PR TITLE
add PR guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+../repo/dot.github/PULL_REQUEST_TEMPLATE.md

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,16 @@ include repo/mk/js.common.node.mk
 
 SF_PATH_FILES_IGNORE := \
 	$(SF_PATH_FILES_IGNORE) \
-	-e "^generic/dot\.gitattributes_global" \
-	-e "^generic/dot\.gitignore_global" \
+	-e "^.github/" \
+	-e "^generic/dot\.gitattributes_global$$" \
+	-e "^generic/dot\.gitignore_global$$" \
 	-e "^repo/AUTHORS$$" \
 	-e "^repo/Brewfile.inc.sh$$" \
+	-e "^repo/cfn/tpl\.Makefile$$" \
+	-e "^repo/dot.github/" \
 	-e "^repo/LICENSE$$" \
 	-e "^repo/NOTICE$$" \
 	-e "^repo/UNLICENSE$$" \
-	-e "^repo/cfn/tpl\.Makefile$$" \
 
 SF_ECLINT_FILES_IGNORE := \
 	$(SF_ECLINT_FILES_IGNORE) \

--- a/bin/repo-generic-bootstrap
+++ b/bin/repo-generic-bootstrap
@@ -84,6 +84,18 @@ ARTIFACT=.travis.yml
     echo_info "Created ${ARTIFACT}."
 }
 
+[[ -e .github ]] || {
+    mkdir -p .github
+    for ARTIFACT in ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot.github/* ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot.github/.*; do
+        ARTIFACT=.github/$(basename ${ARTIFACT})
+        [[ -e ${ARTIFACT} ]] || {
+            ln -s ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot${ARTIFACT} ${ARTIFACT}
+            ARTIFACTS="${ARTIFACTS}\\n${ARTIFACT}"
+            echo_info "Symlinked ${ARTIFACT}."
+        }
+    done
+}
+
 [[ -e .vscode ]] || {
     mkdir -p .vscode
     for ARTIFACT in ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot.vscode/* ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot.vscode/.*; do

--- a/doc/working-with-git-pr.md
+++ b/doc/working-with-git-pr.md
@@ -11,10 +11,10 @@ When opening a Pull Request, or when reviewing someone else's Pull Request,
 follow these guidelines:
 
 0. Small is Best
-1. Correctness
-2. Consistency
-3. Readability
-4. Knowledge Sharing (extra)
+1. Correct
+2. Consistent
+3. Readable
+4. Share Knowledge
 
 ## 0. Small is Best
 
@@ -28,14 +28,14 @@ See also:
 * https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1
 
 
-## 1. Correctness
+## 1. Correct
 
 The changeset needs to be comprehensive and logical.
 
 Code changes should not only add new features or fix bugs, but also not introduce bugs.
 
 
-## 2. Consistency
+## 2. Consistent
 
 The changeset needs to be consistent with itself and with the existing codebase.
 
@@ -46,7 +46,7 @@ When such improvements take place they should take place on their own,
 and they should touch at least the whole repository, if not the whole system.
 
 
-## 3. Readability
+## 3. Readable
 
 The changeset should be rather readable, not just in a working state.
 
@@ -58,7 +58,7 @@ See also:
 * http://typicalprogrammer.com/what-does-code-readability-mean
 
 
-## 4. Knowledge Sharing
+## 4. Share Knowledge
 
 Given that the above guidelines/checks are fullfilled, the reviewer should have the liberty to point out
 alternative code or useful functions/libraries, while the author has the liberty to assimilate or ignore them.

--- a/doc/working-with-git-pr.md
+++ b/doc/working-with-git-pr.md
@@ -1,0 +1,93 @@
+# git and Pull Requests
+
+**NOTE** Make sure that `make check` passes and maybe `make all test` as well,
+before opening a Pull Request.
+
+Once you are done with your feature branch and/or you would like to request feedback
+and have it merged into master, it is time to initiate a Pull Request (short PR)
+and have someone review your changeset.
+
+When opening a Pull Request, or when reviewing someone else's Pull Request,
+follow these guidelines:
+
+0. Small is Best
+1. Correctness
+2. Consistency
+3. Readability
+4. Knowledge Sharing (extra)
+
+## 0. Small is Best
+
+The changeset needs to focus on one thing and one thing alone.
+
+This is good for both the author and the reviewer,
+since the problem and the changeset addressing the problem is easier to parse and review,
+resulting in a quick turnaround but also in higher quality of the review process.
+
+See also:
+* https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1
+
+
+## 1. Correctness
+
+The changeset needs to be comprehensive and logical.
+
+Code changes should not only add new features or fix bugs, but also not introduce bugs.
+
+
+## 2. Consistency
+
+The changeset needs to be consistent with itself and with the existing codebase.
+
+Coding paradigms and namings can always be improved in the eye of the beholder,
+yet consistency should have a higher value.
+
+When such improvements take place they should take place on their own,
+and they should touch at least the whole repository, if not the whole system.
+
+
+## 3. Readability
+
+The changeset should be rather readable, not just in a working state.
+
+This guideline may seem subjective, but readability is not to be confused with personal preference.
+It has much more to do with simplicity, rather than with easy (how fast/easy it is for a person to read it).
+
+See also:
+* https://wildlyinaccurate.com/what-makes-code-readable/
+* http://typicalprogrammer.com/what-does-code-readability-mean
+
+
+## 4. Knowledge Sharing
+
+Given that the above guidelines/checks are fullfilled, the reviewer should have the liberty to point out
+alternative code or useful functions/libraries, while the author has the liberty to assimilate or ignore them.
+
+Take the opportunity of a PR to discuss and interact!
+
+
+## Miscellaneous
+
+**Stylistic comments are not to be part of a review.**
+If anyone wants to address a stylistic issue, it should be done separately
+by changing the automatism of the relevant style checker:
+open a new PR to add/change a rule's configuration, in the current repository or globally in
+e.g. `eslint-config-firecloud`, `support-firecloud:repo/mk/*.check.*.inc.mk` and similar.
+
+A pull request may address an already existing issue.
+In such a case, **make sure to reference the existing issue**, either in the commit message,
+or in the description of the PR. See https://help.github.com/articles/closing-issues-using-keywords/.
+
+A reviewer is required to act on the Pull Request only after the automated checks pass (e.g. associated Travis job).
+
+## References
+
+**MUST** read:
+* https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
+* https://blog.philipphauer.de/code-review-guidelines/
+
+Optional read:
+* https://dev.to/samjarman/giving-and-receiving-great-code-reviews
+* https://dev.to/codemouse92/10-principles-of-a-good-code-review-2eg
+* https://blog.scottnonnenberg.com/top-ten-pull-request-review-mistakes/
+* https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md

--- a/doc/working-with-git.md
+++ b/doc/working-with-git.md
@@ -15,6 +15,11 @@ like your username e.g.
 * DONT `add-logo`
 
 
+## Pull requests
+
+See [git and Pull Requests](./working-with-git-pr.md).
+
+
 ## New repositories
 
 See [new git (and Github) repositories](./working-with-git-new.md).

--- a/repo/dot.github/PULL_REQUEST_TEMPLATE.md
+++ b/repo/dot.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Thank you for your contribution!
+
+Please remember to follow our guidelines
+https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
+
+0. Small is Best
+1. Correctness
+2. Consistency
+3. Readability
+4. Knowledge Sharing
+
+And make sure that `make check` passes and maybe `make all test` as well.
+-->
+
+Fixes: <!-- Paste the link to the GitHub issue that this PR is fixing -->
+
+Breaking change: [ ] <!-- Insert an 'x' between the square brackets if this is a breaking change -->
+
+---
+
+<!-- Describe your changeset after this line, if title is not enough -->

--- a/repo/dot.github/PULL_REQUEST_TEMPLATE.md
+++ b/repo/dot.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,10 @@ Please remember to follow our guidelines
 https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
 
 0. Small is Best
-1. Correctness
-2. Consistency
-3. Readability
-4. Knowledge Sharing
+1. Correct
+2. Consistent
+3. Readable
+4. Share Knowledge
 
 And make sure that `make check` passes and maybe `make all test` as well.
 -->


### PR DESCRIPTION
@IanSavchenko and I sat down and came up with a short list of guidelines for PRs (for authors and reviewers alike), and I expanded on it.

Fishing for feedback 🎣 

~PS: from a hands-on POV, `support-firecloud` could have a pull-request template https://blog.github.com/2016-02-17-issue-and-pull-request-templates/ which would then be symlinked and used across all our repos. Not part of this PR, but do say if you would like us to have one (smth simple, maybe just listing the guidelines, and linking to this doc section for further reading, as a reminder every time we open a PR)~ Pull request template added