### PR TITLE
Placeholder for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,6 @@ aliases:
           only:
             - master
 
-  - filter-pr: &filter-pr
-      filters:
-        branches:
-          only:
-            - /^refs\/pull\/.+$/
-
 
 executors:
   docker:
@@ -154,14 +148,6 @@ workflows:
           <<: *job-main-linux-xenial-common
       - main-macos-xcode101-dev:
           <<: *job-main-macos-xcode101-dev
-
-  pr:
-    <<: *filter-pr
-    jobs:
-      - main-linux-trusty-minimal:
-          <<: *job-main-linux-trusty-minimal
-      - main-linux-xenial-minimal:
-          <<: *job-main-linux-xenial-minimal
 
   nightly:
     <<: *filter-main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,182 @@
+version: 2.1
+
+
+aliases:
+  - &step_restore_cache
+    restore_cache:
+      keys:
+        - v1-{{ .Branch }}-<< parameters.p_cache_name >>-{{ checksum "~/week-number" }}
+        - v1-master-<< parameters.p_cache_name >>-{{ checksum "~/week-number" }}
+
+  - &step_save_cache
+    save_cache:
+      key: v1-{{ .Branch }}-<< parameters.p_cache_name >>-{{ checksum "~/week-number" }}
+      paths:
+        # common
+        - ~/.local
+        - ~/.npm
+        # darwin
+        - ~/.homebrew
+        - ~/Library/Caches/Homebrew
+        - ~/Library/Caches/pip
+        # linux
+        - ~/.cache/Homebrew
+        - ~/.cache/pip
+        - ~/.linuxbrew
+
+  - job-main-linux-trusty-minimal: &job-main-linux-trusty-minimal
+      p_executor:
+        name: docker
+        p_image: circleci/buildpack-deps:trusty
+      p_cache_name: linux-trusty-minimal
+      p_install: minimal
+
+  - job-main-linux-trusty-common: &job-main-linux-trusty-common
+      p_executor:
+        name: docker
+        p_image: circleci/buildpack-deps:trusty
+      p_cache_name: linux-trusty-common
+      p_install: common
+
+  - job-main-linux-xenial-minimal: &job-main-linux-xenial-minimal
+      p_executor:
+        name: docker
+        p_image: circleci/buildpack-deps:xenial
+      p_cache_name: linux-xenial-minimal
+      p_install: minimal
+
+  - job-main-linux-xenial-common: &job-main-linux-xenial-common
+      p_executor:
+        name: docker
+        p_image: circleci/buildpack-deps:xenial
+      p_cache_name: linux-xenial-common
+      p_install: common
+
+  - job-main-macos-xcode101-dev: &job-main-macos-xcode101-dev
+      p_executor:
+        name: macos
+        p_xcode: "10.1.0"
+      p_cache_name: macos-xcode10.1-dev
+      p_install: dev
+
+  - filter-main: &filter-main
+      filters:
+        branches:
+          only:
+            - master
+
+  - filter-pr: &filter-pr
+      filters:
+        branches:
+          only:
+            - /^refs\/pull\/.+$/
+
+
+executors:
+  docker:
+    parameters:
+      p_image:
+        type: string
+    docker:
+      - image: << parameters.p_image >>
+
+  macos:
+    parameters:
+      p_xcode:
+        type: string
+    macos:
+      xcode: << parameters.p_xcode >>
+
+
+jobs:
+  main: &job-main
+    parameters:
+      p_executor:
+        type: executor
+      p_cache_name:
+        type: string
+      p_install:
+        type: string
+    executor: << parameters.p_executor >>
+    steps:
+      - run: echo "SF_CI_BREW_INSTALL=<< parameters.p_install >>" >> $BASH_ENV
+      - run: echo "SF_LOG_BOOTSTRAP=true" >> $BASH_ENV
+      - run: date +%v > ~/week-number
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init --recursive
+      - *step_restore_cache
+      - run: ./.ci.sh before_install
+      - run: ./.ci.sh install
+      - run: ./.ci.sh before_script
+      - run: ./.ci.sh script
+      - run:
+          when: on_fail
+          command: ./.ci.sh after_failure
+      - run:
+          when: on_success
+          command: ./.ci.sh after_success
+      - run:
+          when: always
+          command: ./.ci.sh after_script
+      - run: ./.ci.sh before_cache
+      - *step_save_cache
+
+  main-linux-trusty-minimal:
+    <<: *job-main
+
+  main-linux-trusty-common:
+    <<: *job-main
+
+  main-linux-xenial-minimal:
+    <<: *job-main
+
+  main-linux-xenial-common:
+    <<: *job-main
+
+  main-macos-xcode101-dev:
+    <<: *job-main
+
+
+workflows:
+  version: 2.1
+
+  main:
+    <<: *filter-main
+    jobs:
+      - main-linux-trusty-minimal:
+          <<: *job-main-linux-trusty-minimal
+      - main-linux-trusty-common:
+          <<: *job-main-linux-trusty-common
+      - main-linux-xenial-minimal:
+          <<: *job-main-linux-xenial-minimal
+      - main-linux-xenial-common:
+          <<: *job-main-linux-xenial-common
+      - main-macos-xcode101-dev:
+          <<: *job-main-macos-xcode101-dev
+
+  pr:
+    <<: *filter-pr
+    jobs:
+      - main-linux-trusty-minimal:
+          <<: *job-main-linux-trusty-minimal
+      - main-linux-xenial-minimal:
+          <<: *job-main-linux-xenial-minimal
+
+  nightly:
+    <<: *filter-main
+    triggers:
+      - schedule:
+          <<: *filter-main
+          cron: "0 0 * * *"
+    jobs:
+      - main-linux-trusty-minimal:
+          <<: *job-main-linux-trusty-minimal
+      - main-linux-trusty-common:
+          <<: *job-main-linux-trusty-common
+      - main-linux-xenial-minimal:
+          <<: *job-main-linux-xenial-minimal
+      - main-linux-xenial-common:
+          <<: *job-main-linux-xenial-common
+      - main-macos-xcode101-dev:
+          <<: *job-main-macos-xcode101-dev

--- a/repo/dot.ci.sh.sf
+++ b/repo/dot.ci.sh.sf
@@ -302,4 +302,12 @@ EOF
     CI_IS_PR=$([[ "${TRAVIS_EVENT_TYPE}" = "pull_request" ]] && echo true || true)
 }
 
+[[ "${CIRCLECI:-}" != "true" ]] || {
+    CI_DEBUG_MODE=${CI_DEBUG_MODE:-}
+    CI_JOB_ID=${CIRCLE_WORKFLOW_JOB_ID}
+    CI_JOB_URL=https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}
+    CI_REPO_SLUG=${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+    CI_IS_PR=$([[ -n "${CIRCLE_PR_NUMBER:-}" || -n "${CIRCLE_PULL_REQUEST:-}" ]] && echo true || true)
+}
+
 [[ -z "$*" ]] || sf_ci_run $@


### PR DESCRIPTION
Concluding some minimum exploration of CircleCI as an alternative for the current TravisCI. Here's some random minuses

*Caches*: CircleCI caches are "immutable", and there seems to be no easy way to go around that i.e. to make job `n` restore the cache of job `n-1` of the same workflow&branch. Clearing caches is also not a feature at the moment, so the only thing to do is bump up a "version" marker in the cache name.

*UI*: maybe it's a matter of getting used to it, but clicking through the UI just for the purpose of browsing the workflow-to-job-and-back info is not optimized

*Logs*: no way to download raw logs from UI. I guess there's an API for it?! Also there is no code folding feature, so the logs could be sometimes hard to parse visually.

*Config*: rather duplicative and hard to follow. While support-firecloud's config is an outlier, overusing yaml references was a must, and just for the purpose of having a PR flow and a nightly flow, they will still be needed. No support for encrypted variables, but not a biggie.

*Docs*: I would say low-to-medium quality, a mix of info from CircleCI 1.0 and 2.0 and 2.1. The configuration I wrote for support-firecloud is half baked by googling the "CircleCI Discuss" platform.

*Features/Community*: it looks like there are core features that people see in other CI services, which are lingering to be implemented/ported to CircleCI, while at the same time some "features" (e.g. immutable caches) exist without having public support.

*Debug*: SSH debugging is available, but CircleCI triggers another run of the job to debug, and only afterwards it prints the SSH info. Also, it looks like the machine is available for 2 hours, allowing for multiple SSH sessions (a minus for security).

**EDIT** PR: one cannot have different workflows for PRs without shell hacks https://discuss.circleci.com/t/workflows-pull-request-filter/14396

---

My 2penny: good alternative, but might be bumpy.

PS: nice to see so few Travis specifics. I just needed to export some env vars, and everything worked. So porting to another CI is mainly equivalent to rewriting the configuration around what to run, when to run and cache.