### PR TITLE
F/ian vscode update

### DIFF
--- a/bin/repo-generic-bootstrap
+++ b/bin/repo-generic-bootstrap
@@ -101,9 +101,9 @@ ARTIFACT=.travis.yml
     for ARTIFACT in ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot.vscode/* ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot.vscode/.*; do
         ARTIFACT=.vscode/$(basename ${ARTIFACT})
         [[ -e ${ARTIFACT} ]] || {
-            ln -s ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot${ARTIFACT} ${ARTIFACT}
+            cp ${SUPPORT_FIRECLOUD_DIR_REL}/repo/dot${ARTIFACT} ${ARTIFACT}
             ARTIFACTS="${ARTIFACTS}\\n${ARTIFACT}"
-            echo_info "Symlinked ${ARTIFACT}."
+            echo_info "Created ${ARTIFACT}."
         }
     done
 }

--- a/generic/dot.gitignore_global
+++ b/generic/dot.gitignore_global
@@ -23,5 +23,4 @@ yarn-error.log*
 .vscode/*
 !.vscode/extensions.json
 !.vscode/launch.json
-!.vscode/settings.json
 !.vscode/tasks.json


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes: #96 
* Breaking change: [ ]

---

Two things changed: 

1. Do not track changes on `.vscode/settings.json` by adding it to `.gitignore_global`. Reason: people (me) want to do local customizations of settings per repo that should not be committed and should not be even visible to git. 

Problems:
a) on the repo init need to commit the `.vscode/settings.json` forcefully (and every time you want to push any changes).
b) `make nuke` will reset local changes. So probably, need to add some kind of exception.

2. On the repo init, copy `.vscode` boilerplate files, instead of symlinking them. 
I believe it will be better in the long run, because it will remove a barrier for their modification ("Oh, I'm changing support-firecloud! Does my change really apply for everyone?"). 

Right now we have there: 
* `.editorconfig` - probably, won't change ever.
* `extensions.json` - has only extensions recommendations, which are actually useful and would be good to be updated on per-repo basis
* `settings.json` - should be repo specific too, even not tracked, see more above
* `tasks.json` - also, usually specific for each repo. I would like to leverage more of them, especially to launch debugger faster.

Ofc, as we discussed this many times, symlinks can be unsymlinked any time, but again - it's a barrier. 
Another argument for this change: these files were not changed in SF for a year or more, so it means that they are pretty stable. And when we make the changing process easier, maybe, we will start using more customizations to those files and find new cool stuff to be included in the boilerplate.