### PR TITLE
run 'make check' before 'git push'

### DIFF
--- a/repo/dot.git/hooks/pre-push
+++ b/repo/dot.git/hooks/pre-push
@@ -3,4 +3,12 @@
 SUPPORT_FIRECLOUD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../support-firecloud" && pwd)"
 source ${SUPPORT_FIRECLOUD_DIR}/sh/common.inc.sh
 
+GIT_MODIFIED_FILES="$(git diff --name-only)"
+[[ -z "${GIT_MODIFIED_FILES}" ]] || {
+    echo_warn "The files below are modified and unstaged,"
+    echo_warn "but 'make check' will use the whole file content,"
+    echo_warn "so the push might fail because of unstaged changes, not related to the new commits."
+    echo "${GIT_MODIFIED_FILES}"
+}
+
 make check

--- a/repo/dot.git/hooks/pre-push
+++ b/repo/dot.git/hooks/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+SUPPORT_FIRECLOUD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../support-firecloud" && pwd)"
+source ${SUPPORT_FIRECLOUD_DIR}/sh/common.inc.sh
+
+make check

--- a/repo/dot.git/hooks/pre-push
+++ b/repo/dot.git/hooks/pre-push
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+function on_exit() {
+    [[ "$?" != "0" ]] || return
+
+    echo "[ERR ] pre-push hook failed."
+    echo "[INFO] If you want ignore the hook and push anyway, use 'git push --no-verify ...'."
+}
+
+trap on_exit EXIT
+
 SUPPORT_FIRECLOUD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../support-firecloud" && pwd)"
 source ${SUPPORT_FIRECLOUD_DIR}/sh/common.inc.sh
 

--- a/repo/mk/core.deps.git-hook-pre-push.mk
+++ b/repo/mk/core.deps.git-hook-pre-push.mk
@@ -1,0 +1,19 @@
+# install a pre-push git hook that runs 'make check' on 'git push', before pushing to remote
+
+# the hook can be ignored one time by running 'git push --no-verify'
+
+# the hook can be not-installed by adding to the Makefile:
+# SF_DEPS_TARGETS := $(filter-out .git/hooks/pre-push,$(SF_DEPS_TARGETS))
+
+ifneq ($(wildcard .git),)
+SF_DEPS_TARGETS := \
+	$(SF_DEPS_TARGETS) \
+	.git/hooks/pre-push \
+
+endif
+
+# ------------------------------------------------------------------------------
+
+.git/hooks/pre-push:
+	$(MKDIR) $(shell dirname $@)
+	$(CP) $(SUPPORT_FIRECLOUD_DIR)/repo/dot.git/hooks/pre-push $@

--- a/repo/mk/core.deps.git-hook-pre-push.mk
+++ b/repo/mk/core.deps.git-hook-pre-push.mk
@@ -14,6 +14,6 @@ endif
 
 # ------------------------------------------------------------------------------
 
-.git/hooks/pre-push:
+.git/hooks/pre-push: $(SUPPORT_FIRECLOUD_DIR)/repo/dot.git/hooks/pre-push
 	$(MKDIR) $(shell dirname $@)
 	$(CP) $(SUPPORT_FIRECLOUD_DIR)/repo/dot.git/hooks/pre-push $@

--- a/repo/mk/generic.common.mk
+++ b/repo/mk/generic.common.mk
@@ -1,6 +1,7 @@
 SUPPORT_FIRECLOUD_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))/../..))
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.common.mk
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.vendor.transcrypt.mk
+include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.deps.git-hook-pre-push.mk
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.check.path.mk
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.check.eclint.mk
 include $(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.check.jsonlint.mk


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
goal is to have a quick feedback cycle, as opposed to pushing code that will trigger a CI agent to spin up, bootstrap itself, fetch dependencies, build your code and only then fail with "expected 2 spaces, not 3"

it is a pre-push hook, as opposed to a pre-commit because

1. you should be allowed to commit "wip" code, rewrite history to clean it up, etc
2. `make check` is fast, but not that fast, so depending on the size of the repo, you might be looking at ~1 minute waiting time (atex-platform and gs-server have ~40 seconds)

I ran it with positive outcomes for a couple of weeks myself

NOTE that the PR in its current form wants to make this the default with a opt-out (potentially for repos like atex-platform and gs-server). The alternative would be to make it a opt-in, and then have each repo add a line to their root Makefiles that includes this inc.mk file. The threshold of how much is too much is subjective, but I can only guess that it is a good-to-have for most of the repos thus the proposition to have it on by default, and off for only those "monolithic" repos.

// @fredrikj @jonashogstrom you were talking of doing the same, thus your feedback is appreciated