### PR TITLE
add editorconfig-checker. fix #149

### DIFF
--- a/ci/brew-install-core.inc.sh
+++ b/ci/brew-install-core.inc.sh
@@ -8,6 +8,7 @@ else
     echo_do "brew: Installing core packages..."
     # 'findutils' provides 'xargs', because the OSX version has no 'xargs -r'
     BREW_FORMULAE="$(cat <<-EOF
+${SUPPORT_FIRECLOUD_DIR}/priv/editorconfig-checker.rb
 ${SUPPORT_FIRECLOUD_DIR}/priv/retry.rb
 bash
 curl
@@ -27,6 +28,7 @@ EOF
     echo_do "brew: Testing core packages..."
     exe_and_grep_q "bash --version | head -1" "^GNU bash, version [^123]\\."
     exe_and_grep_q "curl --version | head -1" "^curl 7\\."
+    exe_and_grep_q "editorconfig-checker --version | head -1" "^2\\."
     exe_and_grep_q "git --version | head -1" "^git version 2\\."
     exe_and_grep_q "jq --version | head -1" "^jq\\-1\\."
     exe_and_grep_q "make --version | head -1" "^GNU Make 4\\."

--- a/priv/editorconfig-checker.rb
+++ b/priv/editorconfig-checker.rb
@@ -1,0 +1,62 @@
+# WARNING: DO NOT EDIT. AUTO-GENERATED CODE (editorconfig-checker.rb.tpl)
+
+class EditorconfigChecker < Formula
+  version "2.0.3"
+  bottle :unneeded
+
+  if OS.mac?
+    if Hardware::CPU.is_64_bit?
+      url "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.0.3/ec-darwin-amd64.tar.gz"
+      sha256 "c6d646f8057eccde7ad85225fc5dd54a2e7124929a1b61d2f053c343102ed91e"
+    else
+      url "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.0.3/ec-darwin-386.tar.gz"
+      sha256 "b58367263b45740d50733b4b4533c10c7434ddba5794609eb4c007dd1cb4bcfd"
+    end
+  elsif OS.linux?
+    if Hardware::CPU.intel?
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.0.3/ec-linux-amd64.tar.gz"
+        sha256 "8c61c1bfc82a219f87a700bc04f868bf04a7e9b8854cddae6a781405b3f2e7d5"
+      else
+        url "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.0.3/ec-linux-386.tar.gz"
+        sha256 "ade995b1c828564f1a3c9694ac15a52cc4c8e57d7a0a559b423cf63b2ea90602"
+      end
+    elsif Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.0.3/ec-linux-arm64.tar.gz"
+        sha256 "8010008c2109d8c168bb76248cc4e69aaa8843325fe199f9db4ac098f8f40e6b"
+      else
+        url "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.0.3/ec-linux-arm.tar.gz"
+        sha256 "281943af43a4455140ac4352abf2a423e5faad38ffcf5439f7b5105e4a4f7ce7"
+      end
+    end
+  end
+
+  def install
+    if OS.mac?
+      if Hardware::CPU.is_64_bit?
+        bin.install "ec-darwin-amd64" => "editorconfig-checker"
+      else
+        bin.install "ec-darwin-386" => "editorconfig-checker"
+      end
+    elsif OS.linux?
+      if Hardware::CPU.intel?
+        if Hardware::CPU.is_64_bit?
+          bin.install "ec-linux-amd64" => "editorconfig-checker"
+        else
+          bin.install "ec-linux-386" => "editorconfig-checker"
+        end
+      elsif Hardware::CPU.arm?
+        if Hardware::CPU.is_64_bit?
+          bin.install "ec-linux-arm64" => "editorconfig-checker"
+        else
+          bin.install "ec-linux-arm" => "editorconfig-checker"
+        end
+      end
+    end
+  end
+
+  test do
+    system "#{bin}/editorconfig-checker -v"
+  end
+end

--- a/priv/editorconfig-checker.rb.tpl
+++ b/priv/editorconfig-checker.rb.tpl
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VSN=2.0.3
+
+RB_FILE=${BASH_SOURCE[0]%.tpl}
+# ID must be the PascalCase version of the RB_FILE
+ID="$(basename "${RB_FILE%.rb}" | sed -r "s/(^|[^a-z])([a-z])/\U\2/g")" # EditorconfigChecker
+BIN=editorconfig-checker
+
+function get_asset_url() {
+  OS=$1
+  ARCH=$2
+
+  echo "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${VSN}/ec-${OS}-${ARCH}.tar.gz"
+}
+
+function get_asset_sha256() {
+  OS=$1
+  ARCH=$2
+
+  curl -q -fsS -L "$(get_asset_url "${OS}" "${ARCH}")" | sha256sum | cut -d" " -f1
+}
+
+function get_bin() {
+  OS=$1
+  ARCH=$2
+
+  echo "ec-${OS}-${ARCH}"
+}
+
+cat <<EOF > ${RB_FILE}
+# WARNING: DO NOT EDIT. AUTO-GENERATED CODE (${BASH_SOURCE[0]})
+
+class ${ID} < Formula
+  version "${VSN}"
+  bottle :unneeded
+
+  if OS.mac?
+    if Hardware::CPU.is_64_bit?
+      url "$(get_asset_url darwin amd64)"
+      sha256 "$(get_asset_sha256 darwin amd64)"
+    else
+      url "$(get_asset_url darwin 386)"
+      sha256 "$(get_asset_sha256 darwin 386)"
+    end
+  elsif OS.linux?
+    if Hardware::CPU.intel?
+      if Hardware::CPU.is_64_bit?
+        url "$(get_asset_url linux amd64)"
+        sha256 "$(get_asset_sha256 linux amd64)"
+      else
+        url "$(get_asset_url linux 386)"
+        sha256 "$(get_asset_sha256 linux 386)"
+      end
+    elsif Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        url "$(get_asset_url linux arm64)"
+        sha256 "$(get_asset_sha256 linux arm64)"
+      else
+        url "$(get_asset_url linux arm)"
+        sha256 "$(get_asset_sha256 linux arm)"
+      end
+    end
+  end
+
+  def install
+    if OS.mac?
+      if Hardware::CPU.is_64_bit?
+        bin.install "$(get_bin darwin amd64)" => "${BIN}"
+      else
+        bin.install "$(get_bin darwin 386)" => "${BIN}"
+      end
+    elsif OS.linux?
+      if Hardware::CPU.intel?
+        if Hardware::CPU.is_64_bit?
+          bin.install "$(get_bin linux amd64)" => "${BIN}"
+        else
+          bin.install "$(get_bin linux 386)" => "${BIN}"
+        end
+      elsif Hardware::CPU.arm?
+        if Hardware::CPU.is_64_bit?
+          bin.install "$(get_bin linux arm64)" => "${BIN}"
+        else
+          bin.install "$(get_bin linux arm)" => "${BIN}"
+        end
+      end
+    end
+  end
+
+  test do
+    system "#{bin}/${BIN} -v"
+  end
+end
+EOF


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes: #149
* Breaking change: [ ]

---

<!-- Describe your contribution -->
1. the reasons for this change are described in #149
2. because devs will not bootstrap their machines immediately, and install editorconfig-checker, we still defaultl to eclint (installed as part of package.json)
3. editorconfig-checker is a golang binary, without a homebrew formula, and without a standalone install script. Since we use homebrew/linuxbrew, I created a local homebrew formula that is easy to update via a template script, when someone wants to bump the version of editorconfig-checker
3. TODO once this is merged, a new issue should be created - a reminder to remove support for eclint, and expect editorconfig-checker to be installed

// cc @fredrikj this should take care of "missing eclint" after running `bin/repo-{generic,node}-bootstrap`, since we don't mention eclint in the `repo/package.json` template