### PR TITLE
add docker-ci target. ref #152

### DIFF
--- a/repo/ci.sh/before-install.pre.inc.sh
+++ b/repo/ci.sh/before-install.pre.inc.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 function sf_run_travis_docker_image() {
-    SF_TRAVIS_DOCKER_IMAGE=${1}
-    CONTAINER_NAME=${2:-sf-docker-ci}
-    MOUNT_DIR=${3:-${HOME}}
+    local SF_TRAVIS_DOCKER_IMAGE=${1}
+    local CONTAINER_NAME=${2:-sf-docker-ci}
+    local MOUNT_DIR=${3:-${HOME}}
 
     echo_do "Spinning up Docker for ${SF_TRAVIS_DOCKER_IMAGE}..."
 

--- a/repo/ci.sh/before-install.pre.inc.sh
+++ b/repo/ci.sh/before-install.pre.inc.sh
@@ -31,32 +31,37 @@ function sf_run_travis_docker_image() {
         touch /support-firecloud.docker-ci
 
     # create same groups (and gids) that the 'travis' user belongs to inside the docker container
-    # NOTE using python instead of getent for compatibility with MacOS
-    for GROUP_NAME in $(id -G --name); do
+    # NOTE groups can have whitespace, thus cannot use a regular for loop,
+    # and instead using a while loop with \0 delimiters
+    while IFS= read -rd '' GROUP_NAME; do
+        # NOTE using python instead of getent for compatibility with MacOS
         exe docker exec -it -u root ${CONTAINER_NAME} \
             addgroup \
             --gid $(python -c "import grp; print(grp.getgrnam(\"${GROUP_NAME}\").gr_gid)") \
-            ${GROUP_NAME} || true;
-    done
+            "${GROUP_NAME// /_}" || true;
+    done < <(id -G --name --zero)
 
     # create same user (and uid) that the 'travis' user has inside the docker container
+    local EFFECTIVE_GROUP_NAME="$(id -g --name)"
     exe docker exec -it -u root ${CONTAINER_NAME} \
         adduser \
         --uid $(id -u) \
-        --ingroup $(id -g --name) \
+        --ingroup "${EFFECTIVE_GROUP_NAME// /_}" \
         --home ${HOME} \
         --shell /bin/sh \
         --disabled-password \
         --gecos "" \
-        $(id -u --name)
+        "$(id -u --name)"
 
     # add the 'travis' user to the groups inside the docker container
-    for GROUP_NAME in $(id -G --name) sudo; do
+    # NOTE groups can have whitespace, thus cannot use a regular for loop,
+    # and instead using a while loop with \0 delimiters
+    while IFS= read -rd '' GROUP_NAME; do
         exe docker exec -it -u root ${CONTAINER_NAME} \
             adduser \
-            $(id -u --name) \
-            ${GROUP_NAME} || true;
-    done
+            "$(id -u --name)" \
+            "${GROUP_NAME// /_}" || true;
+    done < <(id -G --name --zero; echo "sudo\0")
 
     # TODO see dockerfiles/sf-ubuntu-xenial/script.sh
     # the 'travis' user needs to own /home/linuxbrew in order to run linuxbrew successfully

--- a/repo/ci.sh/debug.inc.sh
+++ b/repo/ci.sh/debug.inc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-[[ "$1" != "debug" ]] || {
+[[ "${1:-}" != "debug" ]] || {
     echo
     echo "  You can run specific stages like"
     echo "  ./.ci.sh before_install"

--- a/repo/ci.sh/debug.inc.sh
+++ b/repo/ci.sh/debug.inc.sh
@@ -2,9 +2,13 @@
 
 [[ "$1" != "debug" ]] || {
     echo
-    echo "  Creating a debugging subshell..."
+    echo "  You can run specific stages like"
+    echo "  ./.ci.sh before_install"
+    echo "  or you can run them all (before_install, install, before_script, script)"
+    echo "  ./.ci.sh all"
     echo
-    PS1="${debian_chroot:+($debian_chroot)}\u:\w\$ " ${SHELL}
+    # PS1="${debian_chroot:+($debian_chroot)}\u\w\$ " bash
+    PS1="\w\$ " bash
     exit 0
 }
 

--- a/repo/mk/core.misc.docker-ci.mk
+++ b/repo/mk/core.misc.docker-ci.mk
@@ -2,18 +2,11 @@
 #
 # The docker image that is used by the docker-ci container can be adjusted by
 # setting SF_TRAVIS_DOCKER_IMAGE to another image available on the Docker Hub Registry.
-#
-# NOTE SF_TRAVIS_DOCKER_IMAGE should be in sync with SF_TRAVIS_DOCKER_IMAGE in .ci.sh
-# or any other CI configuration that sets the docker image.
-#
-# TODO ideally the duplication in Makefile and .ci.sh of SF_TRAVIS_DOCKER_IMAGE
-# should not exist, but switching to a CI with native docker integration,
-# is going to prove even harder to deduplicate. Rather than focus on deduplication,
-# an alternative is to have a check that the image is the same in all places.
+# By default, SF_TRAVIS_DOCKER_IMAGE is the same as for the .ci.sh script.
 #
 # ------------------------------------------------------------------------------
 
-SF_TRAVIS_DOCKER_IMAGE ?= tobiipro/sf-ubuntu-xenial-minimal
+SF_TRAVIS_DOCKER_IMAGE ?= $(shell source $(GIT_ROOT)/.ci.sh && sf_get_travis_docker_image)
 
 # ------------------------------------------------------------------------------
 

--- a/repo/mk/core.misc.docker-ci.mk
+++ b/repo/mk/core.misc.docker-ci.mk
@@ -1,0 +1,29 @@
+# Adds a 'docker-ci' target to start a local docker-ci container.
+#
+# The docker image that is used by the docker-ci container can be adjusted by
+# setting SF_TRAVIS_DOCKER_IMAGE to another image available on the Docker Hub Registry.
+#
+# NOTE SF_TRAVIS_DOCKER_IMAGE should be in sync with SF_TRAVIS_DOCKER_IMAGE in .ci.sh
+# or any other CI configuration that sets the docker image.
+#
+# TODO ideally the duplication in Makefile and .ci.sh of SF_TRAVIS_DOCKER_IMAGE
+# should not exist, but switching to a CI with native docker integration,
+# is going to prove even harder to deduplicate. Rather than focus on deduplication,
+# an alternative is to have a check that the image is the same in all places.
+#
+# ------------------------------------------------------------------------------
+
+SF_TRAVIS_DOCKER_IMAGE ?= tobiipro/sf-ubuntu-xenial-minimal
+
+# ------------------------------------------------------------------------------
+
+.PHONY: docker-ci
+docker-ci:
+	$(eval CONTAINER_NAME := $(shell echo "sf-docker-ci-$$(basename $(PWD))"))
+	source $(SUPPORT_FIRECLOUD_DIR)/sh/common.inc.sh && \
+		source $(SUPPORT_FIRECLOUD_DIR)/repo/ci.sh/before-install.pre.inc.sh && \
+		sf_run_travis_docker_image $(SF_TRAVIS_DOCKER_IMAGE) $(CONTAINER_NAME) $(PWD)
+	$(ECHO) "[WARN] Make sure to export relevant environment variables!"
+	$(ECHO) "       e.g. secrets in the web UI of Travis CI."
+	docker exec -it -w $(PWD) -u $$(id -u):$$(id -g) $(CONTAINER_NAME) ./.ci.sh debug || true
+	docker kill $(CONTAINER_NAME)

--- a/repo/mk/generic.common.mk
+++ b/repo/mk/generic.common.mk
@@ -26,6 +26,7 @@ SF_GENERIC_COMMON_INCLUDES_DEFAULT += \
 	$(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.misc.sf-update.mk \
 	$(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.misc.snapshot.mk \
 	$(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.misc.transcrypt.mk \
+	$(SUPPORT_FIRECLOUD_DIR)/repo/mk/core.misc.docker-ci.mk \
 
 SF_GENERIC_COMMON_INCLUDES = $(filter-out $(SF_INCLUDES_IGNORE), $(SF_GENERIC_COMMON_INCLUDES_DEFAULT))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes: #152 
* Breaking change: [ ]

---

<!-- Describe your contribution -->
with this PR, running `make docker-ci` will start a docker container in the same fashion as we do on Travis CI, except for exposing the same environment variables set via webui in Travis CI

how to test:
* you can check out the `local-docker-ci` branch in support-firecloud and run `make docker-ci`
* in a repo of your choice that has support-firecloud as a submodule, `cd support-firecloud; git fetch: git co origin/local-docker-ci; cd ..; make docker-ci`

you might see many warnings, since the script tries to reproduce your local env (same username, same groups) in the docker-ci and there's a mismatch between your local env on MacOS and the docker-ci env (on Ubuntu), but it should be good enough.