### PR TITLE
Expose docker.sock when running the docker ci image

### DIFF
--- a/repo/ci.sh/before-install.pre.inc.sh
+++ b/repo/ci.sh/before-install.pre.inc.sh
@@ -90,6 +90,12 @@ function sf_run_docker_ci_image() {
         echo_done
     fi
 
+    # make sure the user has access to the exposed docker.sock
+    echo_do "Modifying permissions of exposed docker.sock..."
+    exe docker exec -it -u root ${CONTAINER_NAME} \
+        chmod 666 /var/run/docker.sock
+    echo_done
+
     # if ${MOUNT_DIR} is under ${HOME}, make sure ${HOME} is writeable
     # to allow for special folders/files e.g. ~/.cache to be accessible for writing
     echo_do "Taking ownership over ${HOME}..."

--- a/repo/ci.sh/before-install.pre.inc.sh
+++ b/repo/ci.sh/before-install.pre.inc.sh
@@ -21,6 +21,7 @@ function sf_run_docker_ci_image() {
         --env-file <([[ "${TRAVIS:-}" != "true" ]] || ${SUPPORT_FIRECLOUD_DIR}/bin/travis-get-env-vars) \
         --env-file <(printenv | grep -e "^TRAVIS") \
         --volume ${MOUNT_DIR}:${MOUNT_DIR}:cached \
+        --volume /var/run/docker.sock:/var/run/docker.sock \
         --privileged \
         --network=host \
         --ipc=host \


### PR DESCRIPTION
Extends the SF docker container that is run in the build process with the exposure of the unix socket that the docker daemon is listening to and the adjustment of the permissions to use the socket.
This enables a second docker instance to run within the SF docker container by reusing the docker.sock (use case in the e2e test for the merlin controller)