### PR TITLE
Build awslogs from source to avoid bug in bottle.

### DIFF
--- a/ci/brew-install-aws.inc.sh
+++ b/ci/brew-install-aws.inc.sh
@@ -2,13 +2,8 @@
 set -euo pipefail
 
 echo_do "brew: Installing AWS utils..."
-BREW_FORMULAE="$(cat <<-EOF
-awscli
-awslogs
-EOF
-)"
-brew_install "${BREW_FORMULAE}"
-unset BREW_FORMULAE
+brew_install awscli
+brew install --build-from-source awslogs
 aws configure set s3.signature_version s3v4
 echo_done
 


### PR DESCRIPTION
When trying to run awslogs, the error message:

error while loading shared libraries: libpython3.8.so.1.0: cannot open shared object file: No such file or directory

means that linux homebrew is downloading the latest awslogs bottle, which 
unfortunately has a broken shared library reference. Building from souce solves this problem.