### PR TITLE
Remove awslogs to avoid bug in bottle

### DIFF
--- a/ci/brew-install-aws.inc.sh
+++ b/ci/brew-install-aws.inc.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 echo_do "brew: Installing AWS utils..."
 BREW_FORMULAE="$(cat <<-EOF
 awscli
-awslogs
 EOF
 )"
 brew_install "${BREW_FORMULAE}"


### PR DESCRIPTION
When trying to run awslogs, the error message:

error while loading shared libraries: libpython3.8.so.1.0: cannot open shared object file: No such file or directory

means that linux homebrew is downloading the latest awslogs bottle, which
unfortunately has a broken shared library reference. Building from souce solves this problem.

But since awslogs is not actually used. Removing it here makes sense.
If it is needed by a project using support-firecloud, the awslogs dependency can
be added to the projects own Brewfile.inc.sh