### PR TITLE
Rename the default canary channel to 'canary'

### DIFF
--- a/repo/mk/core.misc.release.channels.public-makefile.mk
+++ b/repo/mk/core.misc.release.channels.public-makefile.mk
@@ -10,7 +10,7 @@ include support-firecloud/repo/mk/core.misc.release.channels.public-makefile.dep
 # ------------------------------------------------------------------------------
 
 SF_RELEASE_CHANNELS := \
-	merlin \
+	canary \
 	stable \
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
It is more in line with common terms, and also with how we always call it. I should have called it this from the beginning 🤷‍♂️
