### PR TITLE
Allow gettext version 0.21 and don’t care about patch version.

### DIFF
--- a/ci/install-gnu.inc.sh
+++ b/ci/install-gnu.inc.sh
@@ -38,7 +38,7 @@ EOF
     echo_do "gnu: Testing GNU packages..."
     exe_and_grep_q "cat --version | head -1" "^cat (GNU coreutils) 8\\."
     exe_and_grep_q "diff --version | head -1" "^diff (GNU diffutils) 3\\."
-    exe_and_grep_q "envsubst --version | head -1" "^envsubst (GNU gettext-runtime) 0.\(19\|20\)\\."
+    exe_and_grep_q "envsubst --version | head -1" "^envsubst (GNU gettext-runtime) 0.\(19\|20\|21\)"
     exe_and_grep_q "find --version | head -1" "^find (GNU findutils) 4\\."
     exe_and_grep_q "grep --version | head -1" "^grep (GNU grep) 3\\."
     exe_and_grep_q "sed --version | head -1" "^sed (GNU sed) 4\\."


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]
Allows using `gettext` version `0.21` which is the latest one and seemingly the only `gettext` formula available through `brew`.
Also stop looking for the `.` after the minor version.
 ---

<!-- Describe your contribution -->
