### PR TITLE
Fix Gem build error

### DIFF
--- a/ci/linux/bootstrap-sudo
+++ b/ci/linux/bootstrap-sudo
@@ -64,6 +64,7 @@ groff
 python-minimal
 rsync
 uuid-runtime
+zlib1g-dev
 EOF
 )"
 apt_install "${DPKGS}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
Source: https://github.com/Homebrew/brew/issues/5561#issuecomment-530025582
Second source: https://github.com/rokmoln/support-firecloud/commit/32a03dc12e14f81cdf176a91a7d4f7a498cebde6

Fixes the error `Gem::Ext::BuildError: ERROR: Failed to build gem native extension`
