### PR TITLE
handle nvm and .nvmrc

### DIFF
--- a/bin/nvm-get-nvm-bin
+++ b/bin/nvm-get-nvm-bin
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#- nvm-get-nvm-bin 1.0
+## Usage: nvm-get-nvm-bin
+## Print the NVM_DIR environment variables as it would be set after enabling 'nvm'.
+## NOTE: requires the presence of a '.nvmrc' file.
+##
+##   -h, --help     Display this help and exit
+##   -v, --version  Output version information and exit
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            sh_script_usage
+            ;;
+        -v|--version)
+            sh_script_version
+            ;;
+        -* )
+            sh_script_usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+which nvm >/dev/null 2>&1 || {
+    BREW_NVM_DIR=$(brew --prefix nvm 2>/dev/null || true)
+    NVM_SH=
+    [[ ! -f ${HOME}/.nvm/nvm.sh ]] || NVM_SH=${HOME}/.nvm/nvm.sh
+    [[ ! -f ${XDG_CONFIG_HOME:-}/nvm/nvm.sh ]] || NVM_SH=${XDG_CONFIG_HOME}/nvm/nvm.sh
+    [[ ! -f ${BREW_NVM_DIR}/nvm.sh ]] || NVM_SH=${BREW_NVM_DIR}/nvm.sh
+
+    [[ -n ${NVM_SH} ]] || {
+        echo >&2 "[WARN] Couldn't find nvm in any of the known locations."
+        exit 0
+    }
+    set +u
+    source ${NVM_SH} --no-use
+    set -u
+}
+
+set +u
+nvm use >/dev/null 2>&1 || true
+set -u
+
+echo ${NVM_BIN:-}

--- a/ci/brew-install-node.nvm.inc.sh
+++ b/ci/brew-install-node.nvm.inc.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo_do "brew: Installing NVM packages..."
+
+[ -n "${NVM_DIR:-}" ] || export NVM_DIR=~/.nvm
+mkdir -p ${NVM_DIR}
+
+BREW_FORMULAE="$(cat <<-EOF
+nvm
+EOF
+)"
+brew_install "${BREW_FORMULAE}"
+unset BREW_FORMULAE
+
+(
+    set +u
+    source $(brew --prefix nvm)/nvm.sh --no-use
+
+    if [[ -f .nvmrc ]]; then
+        nvm install
+    else
+        nvm install node
+    fi
+    nvm reinstall-packages system
+)
+echo_done
+
+echo_do "brew: Testing NVM packages..."
+(
+    set +u
+    source $(brew --prefix nvm)/nvm.sh --no-use
+    exe_and_grep_q "nvm --version | head -1" "^0\."
+)
+echo_done

--- a/repo/mk/core.common.mk
+++ b/repo/mk/core.common.mk
@@ -19,6 +19,11 @@ ifdef TRAVIS_BRANCH
 GIT_BRANCH = $(TRAVIS_BRANCH)
 endif
 
+ifneq (,$(wildcard .nvmrc))
+NVM_BIN := $(shell $(SUPPORT_FIRECLOUD_DIR)/bin/nvm-get-nvm-bin)
+export PATH := $(NVM_BIN):$(PATH)
+endif
+
 # makefile-folder node_modules exebutables
 PATH_NPM := $(MAKE_PATH)/node_modules/.bin
 # repository node_modules executables

--- a/sh/exe-env.inc.sh
+++ b/sh/exe-env.inc.sh
@@ -33,5 +33,12 @@ if which brew >/dev/null 2>&1; then
     path_prepend ${HOMEBREW_PREFIX}/opt/unzip/bin
     path_prepend ${HOMEBREW_PREFIX}/opt/zip/bin
 
+    [ -n "${NVM_DIR:-}" ] || export NVM_DIR=${HOME}/.nvm
+    type nvm >/dev/null 2>&1 || {
+        NVM_INSTALLATION_DIR=$(brew --prefix nvm 2>/dev/null || true)
+        [ ! -r ${NVM_INSTALLATION_DIR}/nvm.sh ] || source ${NVM_INSTALLATION_DIR}/nvm.sh --no-use
+        unset NVM_INSTALLATION_DIR
+    }
+
     unset HOMEBREW_PREFIX
 fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->

`nvm` https://github.com/nvm-sh/nvm is one node version manager. Two notable alternatives are https://github.com/tj/n and https://github.com/isaacs/nave . In the future, it would be worthwhile to look into `n` as it has no intricate shell setup as `nvm` and `nave` have, and it is also more active than `nvm`.

This PR adds support for nvm in 2 ways:
* `make` calls will automatically have the `PATH` correctly set in order to hit the `node` version specified in the project's `.nvmrc` file (root of the repository only). See changes in `core.common.mk`
* CI and developer environments, which will source `exe-env.inc.sh`, will also have `nvm` enabled, primarily for convenience, for those cases where `node` is called directly e.g. `ng build`, and not via `make`.

Note that the projects that depend on `nvm` would need to add `source ${SUPPORT_FIRECLOUD_DIR}/ci/brew-install-node.nvm.inc.sh` to their `Brewfile.inc.sh` - which will install both `nvm` (via homebrew) but also directly call `nvm install <node version specified in .nvmrc file>`

WARNING: the `nvm-get-nvm-bin` script is not super-super-fast, but still acceptable (~1s), and that each and every call to `make` would imply also one call to `nvm-get-nvm-bin`. Thus there's one (1) second added to each `make` call inside a project with a `.nvmrc` file.

PS: this PR is a port of functionality from https://github.com/rokmoln/support-firecloud . I have not tested the ported functionality.

cc @spschlegel @tobiiasl 