### PR TITLE
brew has stopped supporting 'brew install <url>'

### DIFF
--- a/ci/brew-install-node.inc.sh
+++ b/ci/brew-install-node.inc.sh
@@ -27,8 +27,18 @@ else
                 --grep bottle \
                 Formula/node.rb
         )
-        [[ "${NODE_BOTTLE_COMMIT}" = "" ]] || \
-            NODE_FORMULA="https://raw.githubusercontent.com/${BREW_REPO_SLUG}/${NODE_BOTTLE_COMMIT}/Formula/node.rb"
+        if [[ -n "${NODE_BOTTLE_COMMIT}" ]]; then
+            # NOTE brew has deprecated installing from a URL, but installing from a local file should still work
+            # see https://github.com/Homebrew/brew/pull/7660
+            # Installing from a URL gives:
+            # Error: Calling Installation of node from a GitHub commit URL is disabled! Use 'brew extract node' to stable tap on GitHub instead.
+            RAW_GUC_URL="https://raw.githubusercontent.com"
+            NODE_FORMULA_URL="${RAW_GUC_URL}/${BREW_REPO_SLUG}/${NODE_BOTTLE_COMMIT}/Formula/node.rb"
+            NODE_FORMULA=$(mktemp -d)/node.rb
+            curl -fsSL "${NODE_FORMULA_URL}" -o ${NODE_FORMULA}
+            unset NODE_FORMULA_URL
+            unset RAW_GUC_URL
+        fi
         unset BREW_CORE_TAP_DIR
         unset BREW_REPO_SLUG
         unset BREW_TEST_BOT


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
Implemented a workaround to download the online formula, and install it from local file system instead.

The change https://github.com/Homebrew/brew/pull/7660 references many downsides that don't really hold to be honest - not in this context at least, where we are trying to find the latest formula version from its original tap with a "brewed bottle" (compiled binaries). Thus the naïve workaround.

MacOS green run: https://github.com/rokmoln/support-firecloud/runs/1086216438?check_suite_focus=true