### PR TITLE
fix complaint about package.json is newer than package-lock.json. pac…

### DIFF
--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -182,14 +182,15 @@ check-package-json:
 check-package-lock-json: check-package-json
 	$(eval PACKAGE_JSON_HASH := $(shell $(GIT) log -1 --format='%h' -- package.json))
 	$(eval PACKAGE_LOCK_JSON_HASH := $(shell $(GIT) log -1 --format='%h' -- package-lock.json))
+	$(eval JQ_EXPR := "{a: .name, b: .version, c: .dependencies, d: .devDependencies}")
 	if $(GIT_LS) | $(GREP) -q "^package-lock.json$$"; then \
 		$(GIT) diff --exit-code package-lock.json || { \
 			$(ECHO_ERR) "package-lock.json has changed. Please commit your changes."; \
 			exit 1; \
 		}; \
 		diff \
-			<($(GIT) show $(PACKAGE_LOCK_JSON_HASH):package.json | $(JQ) -S "{dependencies: .dependencies, devDependencies: .devDependencies}") \
-			<($(GIT) show $(PACKAGE_JSON_HASH):package.json | $(JQ) -S "{dependencies: .dependencies, devDependencies: .devDependencies}") || { \
+			<($(GIT) show $(PACKAGE_LOCK_JSON_HASH):package.json | $(JQ) -S $(JQ_EXPR)) \
+			<($(GIT) show $(PACKAGE_JSON_HASH):package.json | $(JQ) -S $(JQ_EXPR)) || { \
 			$(ECHO_ERR) "package.json dependencies have changed without package-lock.json getting updated."; \
 			$(ECHO_INFO) "package.json modified last at $(PACKAGE_JSON_HASH)"; \
 			$(ECHO_INFO) "package-lock.json modified last at $(PACKAGE_LOCK_JSON_HASH)"; \

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -185,4 +185,10 @@ check-package-lock-json: check-package-json
 			$(ECHO_ERR) "package-lock.json has changed. Please commit your changes."; \
 			exit 1; \
 		}; \
+		[[ "$$($(GIT) log -1 --format='%at' -- package-lock.json)" -ge \
+			"$$($(GIT) log -1 --format='%at' -- package.json)" ]] || { \
+			$(ECHO_ERR) "package.json is newer than package-lock.json."; \
+			$(ECHO_ERR) "Please run 'make package-lock.json' and commit your changes."; \
+			exit 1; \
+		}; \
 	fi

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -180,24 +180,20 @@ check-package-json:
 
 .PHONY: check-package-lock-json
 check-package-lock-json: check-package-json
-	$(eval PACKAGE_JSON_TS := $(shell $(GIT) log -1 --format='%at' -- package.json))
 	$(eval PACKAGE_JSON_HASH := $(shell $(GIT) log -1 --format='%h' -- package.json))
-	$(eval PACKAGE_LOCK_JSON_TS := $(shell $(GIT) log -1 --format='%at' -- package-lock.json))
 	$(eval PACKAGE_LOCK_JSON_HASH := $(shell $(GIT) log -1 --format='%h' -- package-lock.json))
 	if $(GIT_LS) | $(GREP) -q "^package-lock.json$$"; then \
 		$(GIT) diff --exit-code package-lock.json || { \
 			$(ECHO_ERR) "package-lock.json has changed. Please commit your changes."; \
 			exit 1; \
 		}; \
-		[[ "$(PACKAGE_LOCK_JSON_TS)" -ge "$(PACKAGE_JSON_TS)" ]] || { \
-			diff \
-				<($(GIT) show $(PACKAGE_LOCK_JSON_HASH):package.json | $(JQ) -S "{dependencies: .dependencies, devDependencies: .devDependencies}") \
-				<($(GIT) show $(PACKAGE_JSON_HASH):package.json | $(JQ) -S "{dependencies: .dependencies, devDependencies: .devDependencies}") || { \
-				$(ECHO_ERR) "package.json dependencies have changed without package-lock.json getting updated."; \
-				$(ECHO_INFO) "package.json modified last at $(PACKAGE_JSON_HASH)"; \
-				$(ECHO_INFO) "package-lock.json modified last at $(PACKAGE_LOCK_JSON_HASH)"; \
-				$(ECHO_INFO) "Please run 'make deps-npm' and commit your changes to package-lock.json."; \
-				exit 1; \
-			}; \
+		diff \
+			<($(GIT) show $(PACKAGE_LOCK_JSON_HASH):package.json | $(JQ) -S "{dependencies: .dependencies, devDependencies: .devDependencies}") \
+			<($(GIT) show $(PACKAGE_JSON_HASH):package.json | $(JQ) -S "{dependencies: .dependencies, devDependencies: .devDependencies}") || { \
+			$(ECHO_ERR) "package.json dependencies have changed without package-lock.json getting updated."; \
+			$(ECHO_INFO) "package.json modified last at $(PACKAGE_JSON_HASH)"; \
+			$(ECHO_INFO) "package-lock.json modified last at $(PACKAGE_LOCK_JSON_HASH)"; \
+			$(ECHO_INFO) "Please run 'make deps-npm' and commit your changes to package-lock.json."; \
+			exit 1; \
 		}; \
 	fi

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -196,7 +196,7 @@ check-package-lock-json: check-package-json
 				$(ECHO_ERR) "package.json dependencies have changed without package-lock.json getting updated."; \
 				$(ECHO_INFO) "package.json modified last at $(PACKAGE_JSON_HASH)"; \
 				$(ECHO_INFO) "package-lock.json modified last at $(PACKAGE_LOCK_JSON_HASH)"; \
-				$(ECHO_INFO) "Please run 'make package-lock.json' and commit your changes."; \
+				$(ECHO_INFO) "Please run 'make deps-npm' and commit your changes to package-lock.json."; \
 				exit 1; \
 			}; \
 		}; \

--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -185,10 +185,4 @@ check-package-lock-json: check-package-json
 			$(ECHO_ERR) "package-lock.json has changed. Please commit your changes."; \
 			exit 1; \
 		}; \
-		[[ "$$($(GIT) log -1 --format='%at' -- package-lock.json)" -ge \
-			"$$($(GIT) log -1 --format='%at' -- package.json)" ]] || { \
-			$(ECHO_ERR) "package.json is newer than package-lock.json."; \
-			$(ECHO_ERR) "Please run 'make package-lock.json' and commit your changes."; \
-			exit 1; \
-		}; \
 	fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
package.json can be edited without changing deps

Rather than removing completely the buggy check, @tobiiasl requested to improve the check.
So the check is now implemented by diffing name, version, dependencies and devDependencies (the only fields I believe that when changed in package.json should be reflected in package-lock.json) between the last git commit hash of package.json and package-lock.json .


```
$ make check-package-lock-json
make: Entering directory '/Users/foo/git/bar'
2a3
>     "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.5.24",
10:46:54 [ERR ] package.json dependencies have changed without package-lock.json getting updated.
10:46:55 [INFO] package.json modified last at 92bc5fc
10:46:57 [INFO] package-lock.json modified last at 5035b1d
10:46:58 [INFO] Please run 'make deps-npm' and commit your changes to package-lock.json.
make: *** [/Users/foo/git/bar/support-firecloud/repo/mk/js.deps.npm.mk:185: check-package-lock-json] Error 1
make: Leaving directory '/Users/foo/git/bar'
```
