### PR TITLE
match case-insensitive 'break' in commit messages when looking for breaking changes

### DIFF
--- a/repo/mk/core.misc.release.channels.public-makefile.deps.mk
+++ b/repo/mk/core.misc.release.channels.public-makefile.deps.mk
@@ -29,7 +29,7 @@ perform-promotion/%:
 		--pretty=format:"%h %ad %s" \
 		--no-decorate \
 		$(GIT_REMOTE)/$(PROMOTE_BRANCH)..$(TAG_COMMIT) | \
-		$(GREP) --color -E "^|break" || true
+		$(GREP) --color -i -E "^|break" || true
 	$(ECHO)
 	$(ECHO_INFO) "Breaking changes ready to be promoted:"
 	$(ECHO)
@@ -40,7 +40,7 @@ perform-promotion/%:
 		--pretty=format:"%h %ad %s" \
 		--no-decorate \
 		$(GIT_REMOTE)/$(PROMOTE_BRANCH)..$(TAG_COMMIT) | \
-		$(GREP) --color -E "break" || true
+		$(GREP) --color -i -E "break" || true
 	$(ECHO)
 	$(ECHO) "[Q   ] Still want to promote $(PROMOTE_BRANCH) to $(TAG)?"
 	$(ECHO) "       Press ENTER to Continue."

--- a/repo/mk/core.misc.sf-update.mk
+++ b/repo/mk/core.misc.sf-update.mk
@@ -44,7 +44,7 @@ support-firecloud/update/v%: _support-firecloud/update ## Update support-fireclo
 		--pretty=format:"%h %ad %s" \
 		--no-decorate \
 		$(SF_UPDATE_COMMIT_RANGE) | \
-		$(GREP) --color -E "^|break" || true
+		$(GREP) --color -i -E "^|break" || true
 	$(ECHO)
 	$(ECHO_INFO) "Breaking changes in $(SF_SUBMODULE_PATH)@$(SF_UPDATE_VSN) since $(SF_VSN):"
 	$(ECHO)
@@ -55,7 +55,7 @@ support-firecloud/update/v%: _support-firecloud/update ## Update support-fireclo
 		--pretty=format:"%h %ad %s" \
 		--no-decorate \
 		$(SF_UPDATE_COMMIT_RANGE) | \
-		$(GREP) --color -E "break" || true
+		$(GREP) --color -i -E "break" || true
 	$(ECHO)
 	$(GIT) -C $(SF_SUBMODULE_PATH) --no-pager \
 		diff --stat $(SF_UPDATE_COMMIT_RANGE)

--- a/repo/mk/env.promote-tag-to-env-branch.mk
+++ b/repo/mk/env.promote-tag-to-env-branch.mk
@@ -30,7 +30,7 @@ promote/%: guard-env-GIT_REMOTE ## promote/<env>/<tag> Promote tag to env branch
 		--pretty=format:"%h %ad %s" \
 		--no-decorate \
 		$(GIT_REMOTE)/$(ENV_BRANCH)..$(TAG_COMMIT) | \
-		$(GREP) --color -E "^|break" || true
+		$(GREP) --color -i -E "^|break" || true
 	$(ECHO)
 	$(ECHO_INFO) "Breaking changes ready to be promoted:"
 	$(ECHO)
@@ -41,7 +41,7 @@ promote/%: guard-env-GIT_REMOTE ## promote/<env>/<tag> Promote tag to env branch
 		--pretty=format:"%h %ad %s" \
 		--no-decorate \
 		$(GIT_REMOTE)/$(ENV_BRANCH)..$(TAG_COMMIT) | \
-		$(GREP) --color -E "break" || true
+		$(GREP) --color -i -E "break" || true
 	$(ECHO)
 	$(ECHO) "[Q   ] Still want to promote $(TAG) to $(ENV_BRANCH)?"
 	$(ECHO) "       Press ENTER to Continue."


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
This should cover cases of committers using capitalized commit messages, like `Breaking change: removed X.`