### PR TITLE
perf: replace $(brew --prefix nvm) with $(brew --prefix)/opt/nvm

### DIFF
--- a/bin/nvm-get-nvm-bin
+++ b/bin/nvm-get-nvm-bin
@@ -27,7 +27,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 which nvm >/dev/null 2>&1 || {
-    BREW_NVM_DIR=$(brew --prefix nvm 2>/dev/null || true)
+    # using a less exact call because 'brew --prefix nvm' is very very slow
+    # BREW_NVM_DIR=$(brew --prefix nvm 2>/dev/null || true)
+    BREW_NVM_DIR=$(brew --prefix)/opt/nvm
     NVM_SH=
     [[ ! -f ${HOME}/.nvm/nvm.sh ]] || NVM_SH=${HOME}/.nvm/nvm.sh
     [[ ! -f ${XDG_CONFIG_HOME:-}/nvm/nvm.sh ]] || NVM_SH=${XDG_CONFIG_HOME}/nvm/nvm.sh

--- a/sh/exe-env.inc.sh
+++ b/sh/exe-env.inc.sh
@@ -35,7 +35,9 @@ if which brew >/dev/null 2>&1; then
 
     [ -n "${NVM_DIR:-}" ] || export NVM_DIR=${HOME}/.nvm
     type nvm >/dev/null 2>&1 || {
-        NVM_INSTALLATION_DIR=$(brew --prefix nvm 2>/dev/null || true)
+        # using a less exact call because 'brew --prefix nvm' is very very slow
+        # NVM_INSTALLATION_DIR=$(brew --prefix nvm 2>/dev/null || true)
+        NVM_INSTALLATION_DIR=${HOMEBREW_PREFIX}/opt/nvm
         [ ! -r ${NVM_INSTALLATION_DIR}/nvm.sh ] || source ${NVM_INSTALLATION_DIR}/nvm.sh --no-use
         unset NVM_INSTALLATION_DIR
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
As described in #182 a call to `brew --prefix nvm` is slow (it's 3 seconds for me), but what I forgot is that there are many calls to it: each make but also each shell script. In the current flow, I can count 10+ calls, so more than half a minute is wasted.

I made a change that should be good in most if not all of the cases. `brew --prefix` is uber fast in comparison.