### PR TITLE
node@15 with npm@7 is full of bugs. lock to node LTS (currently 14)

### DIFF
--- a/ci/brew-install-node.inc.sh
+++ b/ci/brew-install-node.inc.sh
@@ -62,6 +62,12 @@ EOF
     unset BREW_FORMULAE
     unset NODE_FORMULA
 
+    # TODO remove once we can use node@14
+    # see https://github.com/Homebrew/homebrew-core/pull/63410
+    brew unlink node
+    brew install ${SUPPORT_FIRECLOUD_DIR}/priv/node.rb || true
+    brew switch node 14.14.0
+
     # allow npm upgrade to fail on WSL; fails with EACCESS
     IS_WSL=$([[ -e /proc/version ]] && cat /proc/version | grep -q -e "Microsoft" && echo true || echo false)
     npm install --global --force npm@6 || ${IS_WSL}

--- a/priv/node.rb
+++ b/priv/node.rb
@@ -1,0 +1,120 @@
+class Node < Formula
+  desc "Platform built on V8 to build network applications"
+  homepage "https://nodejs.org/"
+  url "https://nodejs.org/dist/v14.14.0/node-v14.14.0.tar.gz"
+  sha256 "afb0b401d62d9fcfc68258f50d0bf042998d349ce9c1d7a2d45dd87870b3aab7"
+  license "MIT"
+  head "https://github.com/nodejs/node.git"
+
+  livecheck do
+    url "https://nodejs.org/dist/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
+  bottle do
+    cellar :any
+    sha256 "f1be3b305c38cc1a71cc089ec1f2983fa6b796f568aac3a6e4c93d79dc87661b" => :catalina
+    sha256 "ff29457f90b4dbf7164a3c8e1204321d3e37e33697006cab136b3e21a238fd02" => :mojave
+    sha256 "42b51e14448f7c4548effecd6f3f4c943785e122096b59ad8d4cb0b5c974faae" => :high_sierra
+    sha256 "4fb8b4fc89de3864e99192f39b329107e1c0d60c899505a60d965323003615e5" => :x86_64_linux
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "python@3.9" => :build
+  depends_on "icu4c"
+
+  # We track major/minor from upstream Node releases.
+  # We will accept *important* npm patch releases when necessary.
+  resource "npm" do
+    url "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz"
+    sha256 "fe8e873cb606c06f67f666b4725eb9122c8927f677c8c0baf1477f0ff81f5a2c"
+  end
+
+  def install
+    # make sure subprocesses spawned by make are using our Python 3
+    ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
+
+    # Never install the bundled "npm", always prefer our
+    # installation from tarball for better packaging control.
+    args = %W[--prefix=#{prefix} --without-npm --with-intl=system-icu]
+    # Remove `--openssl-no-asm` workaround when upstream releases a fix
+    # See also: https://github.com/nodejs/node/issues/34043
+    args << "--openssl-no-asm" if Hardware::CPU.arm?
+    args << "--tag=head" if build.head?
+
+    system "./configure", *args
+    system "make", "install"
+
+    # Allow npm to find Node before installation has completed.
+    ENV.prepend_path "PATH", bin
+
+    bootstrap = buildpath/"npm_bootstrap"
+    bootstrap.install resource("npm")
+    system "node", bootstrap/"bin/npm-cli.js", "install", "-ddd", "--global",
+            "--prefix=#{libexec}", resource("npm").cached_download
+
+    # The `package.json` stores integrity information about the above passed
+    # in `cached_download` npm resource, which breaks `npm -g outdated npm`.
+    # This copies back over the vanilla `package.json` to fix this issue.
+    cp bootstrap/"package.json", libexec/"lib/node_modules/npm"
+    # These symlinks are never used & they've caused issues in the past.
+    rm_rf libexec/"share"
+
+    bash_completion.install bootstrap/"lib/utils/completion.sh" => "npm"
+  end
+
+  def post_install
+    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
+    node_modules.mkpath
+    # Kill npm but preserve all other modules across node updates/upgrades.
+    rm_rf node_modules/"npm"
+
+    cp_r libexec/"lib/node_modules/npm", node_modules
+    # This symlink doesn't hop into homebrew_prefix/bin automatically so
+    # we make our own. This is a small consequence of our
+    # bottle-npm-and-retain-a-private-copy-in-libexec setup
+    # All other installs **do** symlink to homebrew_prefix/bin correctly.
+    # We ln rather than cp this because doing so mimics npm's normal install.
+    ln_sf node_modules/"npm/bin/npm-cli.js", HOMEBREW_PREFIX/"bin/npm"
+    ln_sf node_modules/"npm/bin/npx-cli.js", HOMEBREW_PREFIX/"bin/npx"
+
+    # Create manpage symlinks (or overwrite the old ones)
+    %w[man1 man5 man7].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/legacy-homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      # still needed to migrate from copied file manpages to symlink manpages
+      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.,npx.}*"]
+      ln_sf Dir[node_modules/"npm/man/#{man}/{npm,package-,shrinkwrap-,npx}*"], HOMEBREW_PREFIX/"share/man/#{man}"
+    end
+
+    (node_modules/"npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+
+    output = shell_output("#{bin}/node #{path}").strip
+    assert_equal "hello", output
+    output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat(\"en-EN\").format(1234.56))'").strip
+    assert_equal "1,234.56", output
+
+    output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat(\"de-DE\").format(1234.56))'").strip
+    assert_equal "1.234,56", output
+
+    # make sure npm can find node
+    ENV.prepend_path "PATH", opt_bin
+    ENV.delete "NVM_NODEJS_ORG_MIRROR"
+    assert_equal which("node"), opt_bin/"node"
+    assert_predicate HOMEBREW_PREFIX/"bin/npm", :exist?, "npm must exist"
+    assert_predicate HOMEBREW_PREFIX/"bin/npm", :executable?, "npm must be executable"
+    npm_args = ["-ddd", "--cache=#{HOMEBREW_CACHE}/npm_cache", "--build-from-source"]
+    system "#{HOMEBREW_PREFIX}/bin/npm", *npm_args, "install", ("--unsafe-perm" if Process.uid.zero?), "npm@latest"
+    unless head?
+      system "#{HOMEBREW_PREFIX}/bin/npm", *npm_args, "install", ("--unsafe-perm" if Process.uid.zero?), "bufferutil"
+    end
+    assert_predicate HOMEBREW_PREFIX/"bin/npx", :exist?, "npx must exist"
+    assert_predicate HOMEBREW_PREFIX/"bin/npx", :executable?, "npx must be executable"
+    assert_match "< hello >", shell_output("#{HOMEBREW_PREFIX}/bin/npx cowsay hello")
+  end
+end


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
Node v15 was recently released and homebrew also bumped the `node` formula. Node is and has been stable, but it does come with a built-in component that tends to be quite unstable: npm.

npm v7 has currently 64 open issues, among them a bug around global packages, meaning that `npm install -g json` will not install the json executable in the correct folder https://travis-ci.com/github/tobiipro/support-firecloud/jobs/406928192

![Screenshot 2020-10-26 at 15 36 47](https://user-images.githubusercontent.com/708161/97186387-84326200-17a1-11eb-99b1-393d55774f0b.png)

Since it is not possible to downgrade npm (i.e. `npm i -g npm@6` doesn't work), this PR fixes the situation by locking node to v14 (v14.14.0 to be exact) which is the current LTS version.