### PR TITLE
Look for *.spec.ts files in src folder for jest tests

### DIFF
--- a/repo/mk/js.test.jest.mk
+++ b/repo/mk/js.test.jest.mk
@@ -16,7 +16,7 @@ $(foreach VAR,JEST,$(call make-lazy,$(VAR)))
 JEST_ARGS += \
 
 SF_JEST_TEST_FILES += \
-	$(shell $(FIND_Q_NOSYM) test -type f -name "*.test.js" -print) \
+	$(shell $(FIND_Q_NOSYM) test src -type f \( -name "*.test.js" -o -name "*.spec.ts" \) -print) \
 
 SF_VENDOR_FILES_IGNORE += \
 	-e "/__mocks__/" \


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes: https://github.com/tobiipro/merlin-controller-electron/issues/206
* Breaking change: [ ]

---

<!-- Describe your contribution -->
This PR makes it possible to run jest test files named `*.spec.ts` which are located in the `test` and `src` folder.
The command to use this is e.g. `make a.spec.ts` which will find all files called `a.spec.ts` in the `test` and `src` folder and run them with `jest`.

Explanation:
* src folder added to search path
* group of names with `\( \)` this is optional but was part of an answer I found. It gives the command a bit more structure
* `-o` means `or`, so either `*.test.js` or `*.spec.ts` 