### PR TITLE
Use preinstalled awscli for GH Actions

### DIFF
--- a/ci/brew-install-node.inc.sh
+++ b/ci/brew-install-node.inc.sh
@@ -58,15 +58,31 @@ else
 ${NODE_FORMULA}
 EOF
 )"
-    brew_install "${BREW_FORMULAE}"
+    # Brew updated node to 15 which was incompatible with SF,
+    # so there was a workaround to install node 14 from a local formulae and
+    # brew switch to it.
+    # see https://github.com/Homebrew/homebrew-core/pull/63410
+    #
+    # Recently brew also disabled the switch command however,
+    # see https://github.com/Homebrew/discussions/discussions/339
+    # so the workaround which unlinked whatever version node installed and
+    # switched to the local formulae doesn't work any more either.
+    #
+    # So now the workaround is to only install from the local formulae so we
+    # dont need to do any unlinking or switching.
+    #
+    # This locks our node version to 14 however...
+    # --------------------------------------------------------------------------
+
+    # TODO: Put this back into effect whenever the node version is actually okay
+    # brew_install "${BREW_FORMULAE}"
     unset BREW_FORMULAE
     unset NODE_FORMULA
 
-    # TODO remove once we can use node@14
-    # see https://github.com/Homebrew/homebrew-core/pull/63410
-    brew unlink node
+    # TODO: Put back the comment above and remove this once we can use node@14
+    # brew unlink node
     brew install ${SUPPORT_FIRECLOUD_DIR}/priv/node.rb || true
-    brew switch node 14.14.0
+    # brew switch node 14.14.0
 
     # allow npm upgrade to fail on WSL; fails with EACCESS
     IS_WSL=$([[ -e /proc/version ]] && cat /proc/version | grep -q -e "Microsoft" && echo true || echo false)

--- a/ci/brew-install-node.inc.sh
+++ b/ci/brew-install-node.inc.sh
@@ -11,7 +11,7 @@ else
     NODE_FORMULA=node
     [[ "${CI:-}" != "true" ]] || {
         BREW_CORE_TAP_DIR=$(brew --repo homebrew/core)
-        git -C ${BREW_CORE_TAP_DIR} fetch --depth 1000
+        git -C ${BREW_CORE_TAP_DIR} fetch --unshallow
         BREW_TEST_BOT=BrewTestBot
         BREW_REPO_SLUG=Homebrew/homebrew-core
         [[ "$(uname -s)" != "Linux" ]] || {

--- a/ci/brew-util.inc.sh
+++ b/ci/brew-util.inc.sh
@@ -14,7 +14,7 @@ function brew_update() {
     # Brew is now blocking shallow homebrew/core fetches per Github's request
     # see https://github.com/Homebrew/brew/issues/9420
     BREW_CORE_TAP_DIR=$(brew --repo homebrew/core)
-    git -C ${BREW_CORE_TAP_DIR} fetch --unshallow
+    git -C ${BREW_CORE_TAP_DIR} fetch --depth 1000
     unset BREW_CORE_TAP_DIR
 
     if brew update > $tmpfile 2>&1

--- a/ci/brew-util.inc.sh
+++ b/ci/brew-util.inc.sh
@@ -14,7 +14,7 @@ function brew_update() {
     # Brew is now blocking shallow homebrew/core fetches per Github's request
     # see https://github.com/Homebrew/brew/issues/9420
     BREW_CORE_TAP_DIR=$(brew --repo homebrew/core)
-    git -C ${BREW_CORE_TAP_DIR} fetch --depth 1000
+    git -C ${BREW_CORE_TAP_DIR} fetch --unshallow
     unset BREW_CORE_TAP_DIR
 
     if brew update > $tmpfile 2>&1

--- a/ci/brew-util.inc.sh
+++ b/ci/brew-util.inc.sh
@@ -11,6 +11,12 @@ function brew_update() {
     case "$" in
     esac
 
+    # Brew is now blocking shallow homebrew/core fetches per Github's request
+    # see https://github.com/Homebrew/brew/issues/9420
+    BREW_CORE_TAP_DIR=$(brew --repo homebrew/core)
+    git -C ${BREW_CORE_TAP_DIR} fetch --unshallow
+    unset BREW_CORE_TAP_DIR
+
     if brew update > $tmpfile 2>&1
     then
         rm $tmpfile

--- a/ci/install-aws.inc.sh
+++ b/ci/install-aws.inc.sh
@@ -11,9 +11,21 @@ if [[ "$OS" = "linux" ]] && [[ "${FORCE_BREW:-}" != "true" ]]; then
     pip3 install --upgrade awscli
     echo_done
 else
-    echo_do "brew: Installing AWS utils..."
-    brew_install awscli
-    echo_done
+    if [[ ${GITHUB_ACTIONS:=} == "true" ]]; then
+        # https://github.com/actions/virtual-environments/commit/0fa2247a898625b8020d8dfb1dc4a54ddb2b256c
+        # Github Actions CI already installs awscli via pkg,
+        # which will make 'brew install awscli' fail when linking.
+        # See https://github.com/rokmoln/support-firecloud/runs/1291359454
+        pkgutil --pkgs | grep -q "^com\.amazon\.aws\.cli2" && HAS_AWSCLI_PKG=true || HAS_AWSCLI_PKG=false
+    fi
+    if [[ "${HAS_AWSCLI_PKG:=}" == "true" ]]; then
+        echo_skip "brew: Installing awscli... CI already has awscli preinstalled"
+    else
+        echo_do "brew: Installing AWS utils..."
+        brew_install awscli
+        echo_done
+    fi
+    unset HAS_AWSCLI_PKG
 fi
 
 echo_do "aws: Configure and test AWS utils..."


### PR DESCRIPTION
* Fixes: 
* Breaking change: [ ]

---

Necessary for: https://github.com/tobiipro/merlin-controller-electron/pull/233

<!-- Describe your contribution -->
Brew was failing to link because there were already pre-installed awscli binaries for macos. We changed the install to check if it is already installed, and in that case to skip installing it if the CI is GH-Actions