### PR TITLE
Find last commit package.json was changed (including merge commits)

### DIFF
--- a/repo/mk/js.deps.npm.mk
+++ b/repo/mk/js.deps.npm.mk
@@ -186,8 +186,8 @@ check-package-json:
 
 .PHONY: check-package-lock-json
 check-package-lock-json: check-package-json
-	$(eval PACKAGE_JSON_HASH := $(shell $(GIT) log -1 --format='%h' -- package.json))
-	$(eval PACKAGE_LOCK_JSON_HASH := $(shell $(GIT) log -1 --format='%h' -- package-lock.json))
+	$(eval PACKAGE_JSON_HASH := $(shell $(GIT) rev-list -1 $(GIT_BRANCH) package.json))
+	$(eval PACKAGE_LOCK_JSON_HASH := $(shell $(GIT) rev-list -1 $(GIT_BRANCH) package-lock.json))
 	$(eval JQ_EXPR := "{a: .name, b: .version, c: .dependencies, d: .devDependencies}")
 	if $(GIT_LS) | $(GREP) -q "^package-lock.json$$"; then \
 		$(GIT) diff --exit-code package-lock.json || { \


### PR DESCRIPTION
This PR adds support for the case when `package.json` was last modified in a merge commit.

Before this PR changes done to `package.json` in a merge commit was not handled correctly. Instead the last commit where `package.json` was part of a non-merge commit was used. This could cause false errors in the `check-package-lock-json` make target.